### PR TITLE
Support async Python functions

### DIFF
--- a/src/core/treeSitter/parseStrategies/PythonParseStrategy.ts
+++ b/src/core/treeSitter/parseStrategies/PythonParseStrategy.ts
@@ -92,9 +92,15 @@ export class PythonParseStrategy implements ParseStrategy {
     return match ? line.replace(/:\s*$/, '') : line.replace(/:\s*$/, '');
   }
 
+  /**
+   * Extracts the function signature from the given line.
+   *
+   * The regex supports optional `async` prefixes and return type annotations
+   * such as `async def func(arg: int) -> str:`.
+   */
   private getFunctionSignature(lines: string[], startRow: number): string | null {
     const line = lines[startRow];
-    const match = line.match(/def\s+(\w+)\s*\((.*?)\)(\s*->\s*[^:]+)?:/);
+    const match = line.match(/(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*[^:]+)?\s*:/);
     if (!match) return null;
     return line.replace(/:\s*$/, '');
   }

--- a/src/core/treeSitter/queries/queryPython.ts
+++ b/src/core/treeSitter/queries/queryPython.ts
@@ -20,6 +20,17 @@ export const queryPython = `
 (function_definition
   name: (identifier) @name.definition.function) @definition.function
 
+(function_definition
+  name: (identifier) @name.definition.function
+  return_type: (type) @name.reference.type) @definition.function
+
+(function_definition
+  "async" name: (identifier) @name.definition.function) @definition.function
+
+(function_definition
+  "async" name: (identifier) @name.definition.function
+  return_type: (type) @name.reference.type) @definition.function
+
 (call
   function: [
       (identifier) @name.reference.call

--- a/tests/core/treeSitter/parseFile.python.test.ts
+++ b/tests/core/treeSitter/parseFile.python.test.ts
@@ -116,4 +116,34 @@ describe('parseFile for Python', () => {
       expect(result).toContain(expectContent);
     }
   });
+
+  test('should parse async function without return annotation', async () => {
+    const fileContent = `
+      async def ping():
+          pass
+    `;
+
+    const result = await parseFile(fileContent, 'async_example.py', defaultConfig);
+
+    const expectContents = ['async def ping()'];
+
+    for (const expectContent of expectContents) {
+      expect(result).toContain(expectContent);
+    }
+  });
+
+  test('should parse async function with return annotation', async () => {
+    const fileContent = `
+      async def fetch_data(url: str) -> dict:
+          return {}
+    `;
+
+    const result = await parseFile(fileContent, 'async_example.py', defaultConfig);
+
+    const expectContents = ['async def fetch_data(url: str) -> dict'];
+
+    for (const expectContent of expectContents) {
+      expect(result).toContain(expectContent);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add async function patterns to Python query
- enhance Python signature parsing to handle async and return annotations
- test async Python functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871fb87e9fc8328a65f852cbd2f6307