### PR TITLE
Add optional Python static analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If Repomix has helped you analyze or pack codebases for AI tools, we'd be gratef
 - **Git-Aware**: Automatically respects your `.gitignore` files and `.git/info/exclude`.
 - **Security-Focused**: Incorporates [Secretlint](https://github.com/secretlint/secretlint) for robust security checks to detect and prevent inclusion of sensitive information.
 - **Code Compression**: The `--compress` option uses [Tree-sitter](https://github.com/tree-sitter/tree-sitter) to extract key code elements, reducing token count while preserving structure.
+- **Python Linting**: The `--python-static-analysis` flag runs `pyflakes` on your Python files and reports unused imports or undefined variables.
 
 ## 🚀 Quick Start
 
@@ -552,6 +553,8 @@ Instruction
 
 #### Other Options
 - `--top-files-len <number>`: Number of top files to display in the summary
+- `--python-static-analysis`: Run `pyflakes` on Python files and include a summary
+  in the output. Requires Python 3 and the `pyflakes` package (`pip install pyflakes`).
 - `--verbose`: Enable verbose logging
 - `--quiet`: Disable all output to stdout
 

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -313,6 +313,10 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
     };
   }
 
+  if (options.pythonStaticAnalysis !== undefined) {
+    cliConfig.pythonStaticAnalysis = options.pythonStaticAnalysis;
+  }
+
   try {
     return repomixConfigCliSchema.parse(cliConfig);
   } catch (error) {

--- a/src/cli/cliPrint.ts
+++ b/src/cli/cliPrint.ts
@@ -38,6 +38,15 @@ export const printSummary = (packResult: PackResult, config: RepomixConfigMerged
     }
     logger.log(`${pc.white('    Git Diffs:')} ${gitDiffsMessage}`);
   }
+
+  if (packResult.pythonAnalysisSummary && packResult.pythonAnalysisSummary.length > 0) {
+    logger.log(`${pc.white(' Python Lint:')}`);
+    packResult.pythonAnalysisSummary.forEach((item) => {
+      const count = item.messages.length;
+      const issue = count === 1 ? 'issue' : 'issues';
+      logger.log(pc.dim(`  - ${item.file}: ${count} ${issue}`));
+    });
+  }
 };
 
 export const printSecurityCheck = (

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -106,6 +106,7 @@ export const run = async () => {
       // Other Options
       .optionsGroup('Other Options')
       .option('--top-files-len <number>', 'specify the number of top files to display', Number.parseInt)
+      .option('--python-static-analysis', 'run Python static analysis on Python files')
       .addOption(new Option('--verbose', 'enable verbose logging for detailed output').conflicts('quiet'))
       .addOption(new Option('--quiet', 'disable all output to stdout').conflicts('verbose'))
       .action(commanderActionEndpoint);

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -53,4 +53,5 @@ export interface CliOptions extends OptionValues {
   topFilesLen?: number;
   verbose?: boolean;
   quiet?: boolean;
+  pythonStaticAnalysis?: boolean;
 }

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -64,6 +64,7 @@ export const repomixConfigBaseSchema = z.object({
       encoding: z.string().optional(),
     })
     .optional(),
+  pythonStaticAnalysis: z.boolean().optional(),
 });
 
 // Default config schema with default values
@@ -124,6 +125,7 @@ export const repomixConfigDefaultSchema = z.object({
         .transform((val) => val as TiktokenEncoding),
     })
     .default({}),
+  pythonStaticAnalysis: z.boolean().default(false),
 });
 
 // File-specific schema. Add options for file path and style

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -12,6 +12,8 @@ import { copyToClipboardIfEnabled } from './packager/copyToClipboardIfEnabled.js
 import { writeOutputToDisk } from './packager/writeOutputToDisk.js';
 import type { SuspiciousFileResult } from './security/securityCheck.js';
 import { validateFileSafety } from './security/validateFileSafety.js';
+import type { PythonAnalysisSummary } from './pythonStaticAnalysis.js';
+import { runPythonStaticAnalysis } from './pythonStaticAnalysis.js';
 
 export interface PackResult {
   totalFiles: number;
@@ -24,6 +26,7 @@ export interface PackResult {
   suspiciousGitDiffResults: SuspiciousFileResult[];
   processedFiles: ProcessedFile[];
   safeFilePaths: string[];
+  pythonAnalysisSummary: PythonAnalysisSummary[];
 }
 
 const defaultDeps = {
@@ -37,6 +40,7 @@ const defaultDeps = {
   calculateMetrics,
   sortPaths,
   getGitDiffs,
+  runPythonStaticAnalysis,
 };
 
 export const pack = async (
@@ -93,6 +97,12 @@ export const pack = async (
   progressCallback('Processing files...');
   const processedFiles = await deps.processFiles(safeRawFiles, config, progressCallback);
 
+  let pythonAnalysisSummary: PythonAnalysisSummary[] = [];
+  if (config.pythonStaticAnalysis) {
+    const pythonFiles = safeFilePaths.filter((p) => p.endsWith('.py'));
+    pythonAnalysisSummary = await deps.runPythonStaticAnalysis(pythonFiles, progressCallback);
+  }
+
   progressCallback('Generating output...');
   const output = await deps.generateOutput(rootDirs, config, processedFiles, safeFilePaths, gitDiffResult);
 
@@ -110,6 +120,7 @@ export const pack = async (
     suspiciousGitDiffResults,
     processedFiles,
     safeFilePaths,
+    pythonAnalysisSummary,
   };
 
   return result;

--- a/src/core/pythonStaticAnalysis.ts
+++ b/src/core/pythonStaticAnalysis.ts
@@ -1,0 +1,41 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { logger } from '../shared/logger.js';
+import type { RepomixProgressCallback } from '../shared/types.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface PythonAnalysisSummary {
+  file: string;
+  messages: string[];
+}
+
+export const runPythonStaticAnalysis = async (
+  filePaths: string[],
+  progressCallback: RepomixProgressCallback = () => {},
+  deps = { execFileAsync },
+): Promise<PythonAnalysisSummary[]> => {
+  if (filePaths.length === 0) return [];
+
+  progressCallback('Running Python static analysis...');
+
+  try {
+    const result = await deps.execFileAsync('pyflakes', filePaths);
+    const output = result.stdout.trim();
+    if (!output) return [];
+
+    const summaries: Record<string, string[]> = {};
+    for (const line of output.split('\n')) {
+      const match = line.match(/^(.*?):\d+:\s*(.*)$/);
+      if (match) {
+        const [, file, message] = match;
+        if (!summaries[file]) summaries[file] = [];
+        summaries[file].push(message.trim());
+      }
+    }
+    return Object.entries(summaries).map(([file, messages]) => ({ file, messages }));
+  } catch (error) {
+    logger.warn(`Python static analysis failed: ${(error as Error).message}`);
+    return [];
+  }
+};

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -94,6 +94,7 @@ describe('configSchema', () => {
         tokenCount: {
           encoding: 'o200k_base',
         },
+        pythonStaticAnalysis: false,
       };
       expect(repomixConfigDefaultSchema.parse(validConfig)).toEqual(validConfig);
     });
@@ -188,6 +189,7 @@ describe('configSchema', () => {
         tokenCount: {
           encoding: 'o200k_base',
         },
+        pythonStaticAnalysis: false,
       };
       expect(repomixConfigMergedSchema.parse(validConfig)).toEqual(validConfig);
     });

--- a/tests/core/packager/pythonStaticAnalysis.test.ts
+++ b/tests/core/packager/pythonStaticAnalysis.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, vi } from 'vitest';
+import { pack } from '../../../src/core/packager.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+vi.mock('../../../src/core/pythonStaticAnalysis.js');
+
+const createDeps = () => ({
+  searchFiles: vi.fn().mockResolvedValue({ filePaths: ['main.py'], emptyDirPaths: [] }),
+  sortPaths: vi.fn().mockImplementation((p) => p),
+  collectFiles: vi.fn().mockResolvedValue([{ path: 'main.py', content: 'print(1)' }]),
+  processFiles: vi.fn().mockReturnValue([{ path: 'main.py', content: 'print(1)' }]),
+  validateFileSafety: vi.fn().mockResolvedValue({
+    safeFilePaths: ['main.py'],
+    safeRawFiles: [{ path: 'main.py', content: 'print(1)' }],
+    suspiciousFilesResults: [],
+    suspiciousGitDiffResults: [],
+  }),
+  generateOutput: vi.fn().mockResolvedValue('out'),
+  handleOutput: vi.fn(),
+  copyToClipboardIfEnabled: vi.fn(),
+  calculateMetrics: vi.fn().mockResolvedValue({
+    totalFiles: 1,
+    totalCharacters: 7,
+    totalTokens: 2,
+    fileCharCounts: { 'main.py': 7 },
+    fileTokenCounts: { 'main.py': 2 },
+    gitDiffTokenCount: 0,
+  }),
+  getGitDiffs: vi.fn().mockResolvedValue(undefined),
+  runPythonStaticAnalysis: vi.fn().mockResolvedValue([{ file: 'main.py', messages: ['unused import'] }]),
+});
+
+describe('packager python static analysis', () => {
+  test('runs analysis when enabled', async () => {
+    const config = createMockConfig({ pythonStaticAnalysis: true });
+    const deps = createDeps();
+    const result = await pack(['root'], config, vi.fn(), deps);
+    expect(deps.runPythonStaticAnalysis).toHaveBeenCalledWith(['main.py'], expect.any(Function));
+    expect(result.pythonAnalysisSummary).toEqual([{ file: 'main.py', messages: ['unused import'] }]);
+  });
+
+  test('skips analysis when disabled', async () => {
+    const config = createMockConfig({ pythonStaticAnalysis: false });
+    const deps = createDeps();
+    await pack(['root'], config, vi.fn(), deps);
+    expect(deps.runPythonStaticAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/tests/core/pythonStaticAnalysis.test.ts
+++ b/tests/core/pythonStaticAnalysis.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, vi } from 'vitest';
+import { runPythonStaticAnalysis } from '../../src/core/pythonStaticAnalysis.js';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+const execFileAsync = vi.fn();
+
+describe('runPythonStaticAnalysis', () => {
+  test('parses pyflakes output', async () => {
+    execFileAsync.mockResolvedValue({ stdout: 'a.py:1: unused import os\nb.py:2: undefined name x\n' });
+    const summary = await runPythonStaticAnalysis(['a.py', 'b.py'], vi.fn(), { execFileAsync });
+    expect(execFileAsync).toHaveBeenCalledWith('pyflakes', ['a.py', 'b.py']);
+    expect(summary).toEqual([
+      { file: 'a.py', messages: ['unused import os'] },
+      { file: 'b.py', messages: ['undefined name x'] },
+    ]);
+  });
+
+  test('returns empty array on failure', async () => {
+    execFileAsync.mockRejectedValue(new Error('fail'));
+    const summary = await runPythonStaticAnalysis(['a.py'], vi.fn(), { execFileAsync });
+    expect(summary).toEqual([]);
+  });
+});

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -41,6 +41,7 @@ export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}):
       ...defaultConfig.tokenCount,
       ...config.tokenCount,
     },
+    pythonStaticAnalysis: config.pythonStaticAnalysis ?? defaultConfig.pythonStaticAnalysis,
   };
 };
 


### PR DESCRIPTION
## Summary
- add Python static analysis module
- hook static analysis into packager and CLI
- display lint summary when available
- document `--python-static-analysis` flag
- test Python lint module and packager integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871fe672a688328bc3c6326b5c96b14